### PR TITLE
Add option to save all files before testing

### DIFF
--- a/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/settings/CodeTesterSetting.kt
+++ b/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/settings/CodeTesterSetting.kt
@@ -14,6 +14,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class CodeTesterSetting : PersistentStateComponent<CodeTesterSetting> {
 
     var uniProject = false
+    var saveBeforeTesting = true
 
     companion object {
         fun getInstance(project: Project): CodeTesterSetting {

--- a/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/settings/CodeTesterSettingsComponent.kt
+++ b/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/settings/CodeTesterSettingsComponent.kt
@@ -3,6 +3,7 @@ package com.github.yniklas.intellijcodetesterupload.settings
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.layout.selected
 import com.intellij.util.ui.FormBuilder
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -10,13 +11,16 @@ import javax.swing.JPanel
 class CodeTesterSettingsComponent(project: Project) {
 
     private val panel: JComponent
-    private val cb = JBCheckBox()
+    private val useCheckBox = JBCheckBox()
+    private val saveBeforeTestCheckBox = JBCheckBox()
 
     init {
-        cb.isSelected = CodeTesterSetting.getInstance(project).uniProject
+        useCheckBox.isSelected = CodeTesterSetting.getInstance(project).uniProject
+        saveBeforeTestCheckBox.isSelected = CodeTesterSetting.getInstance(project).saveBeforeTesting
 
         panel = FormBuilder.createFormBuilder()
-            .addLabeledComponent(JBLabel("Use this project for Codetester"), cb)
+            .addLabeledComponent(JBLabel("Use this project for Codetester"), useCheckBox)
+            .addLabeledComponent(JBLabel("Save all files before testing"), saveBeforeTestCheckBox)
             .addComponentFillVertically(JPanel(), 0)
             .panel
     }
@@ -26,11 +30,23 @@ class CodeTesterSettingsComponent(project: Project) {
     }
 
     fun getPreferredFocusedComponent(): JComponent{
-        return cb
+        return useCheckBox
     }
 
-    fun isSelected(): Boolean {
-        return cb.isSelected
+    fun isUseSelected(): Boolean {
+        return useCheckBox.isSelected
+    }
+
+    fun isSaveBeforeTestSelected(): Boolean {
+        return saveBeforeTestCheckBox.isSelected
+    }
+
+    fun setUseSelected(newValue: Boolean) {
+        useCheckBox.isSelected = newValue
+    }
+
+    fun setSaveBeforeTesting(newValue: Boolean) {
+        saveBeforeTestCheckBox.isSelected = newValue
     }
 
 }

--- a/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/settings/CodeTesterSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/settings/CodeTesterSettingsConfigurable.kt
@@ -2,9 +2,6 @@ package com.github.yniklas.intellijcodetesterupload.settings
 
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.ToolWindowManager
-import com.intellij.openapi.wm.impl.ToolWindowsPane
-import com.intellij.ui.content.ContentFactory
 import javax.swing.JComponent
 
 class CodeTesterSettingsConfigurable(private val project: Project) : Configurable {
@@ -35,7 +32,8 @@ class CodeTesterSettingsConfigurable(private val project: Project) : Configurabl
     override fun isModified(): Boolean {
         val settings: CodeTesterSetting = CodeTesterSetting.getInstance(project)
 
-        return settings.uniProject != component?.isSelected()
+        return settings.uniProject != component?.isUseSelected()
+                || settings.saveBeforeTesting != component?.isSaveBeforeTestSelected()
     }
 
     /**
@@ -46,12 +44,14 @@ class CodeTesterSettingsConfigurable(private val project: Project) : Configurabl
      */
     override fun apply() {
         val settings: CodeTesterSetting = CodeTesterSetting.getInstance(project)
-        settings.uniProject = component!!.isSelected()
+        settings.uniProject = component!!.isUseSelected()
+        settings.saveBeforeTesting = component!!.isSaveBeforeTestSelected()
     }
 
     override fun reset() {
         val settings: CodeTesterSetting = CodeTesterSetting.getInstance(project)
-        settings.uniProject = false
+        component!!.setUseSelected(settings.uniProject)
+        component!!.setSaveBeforeTesting(settings.saveBeforeTesting)
     }
 
     override fun getPreferredFocusedComponent(): JComponent {

--- a/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/toolwindow/ToolWindow.kt
+++ b/src/main/kotlin/com/github/yniklas/intellijcodetesterupload/toolwindow/ToolWindow.kt
@@ -3,6 +3,7 @@ package com.github.yniklas.intellijcodetesterupload.toolwindow
 import com.github.yniklas.intellijcodetesterupload.data.ClassResult
 import com.github.yniklas.intellijcodetesterupload.data.TestResult
 import com.github.yniklas.intellijcodetesterupload.data.TestResultMessage
+import com.github.yniklas.intellijcodetesterupload.settings.CodeTesterSetting
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.intellij.credentialStore.CredentialAttributes
@@ -16,6 +17,7 @@ import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.icons.AllIcons
 import com.intellij.ide.passwordSafe.PasswordSafe
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
@@ -96,6 +98,12 @@ class ToolWindow(project: Project, toolWindow: ToolWindow) {
     }
 
     private fun getZipStream(): File {
+        if (CodeTesterSetting.getInstance(project).saveBeforeTesting) {
+            ApplicationManager.getApplication().invokeAndWait {
+                FileDocumentManager.getInstance().saveAllDocuments()
+            }
+        }
+
         val selectedFiles = FileEditorManager.getInstance(project).selectedFiles
 
         if (selectedFiles.isEmpty()) {


### PR DESCRIPTION
All files are now saved before tests are run. This can be turned off in the settings.